### PR TITLE
Path support and security improvements

### DIFF
--- a/lib/libsonic_extra/__init__.py
+++ b/lib/libsonic_extra/__init__.py
@@ -293,7 +293,8 @@ class SubsonicClient(libsonic.Connection):
             parts = list(urlparse.urlparse(
                 args[0].get_full_url() + "?" + args[0].data))
             parts[4] = dict(urlparse.parse_qsl(parts[4]))
-            parts[4].update({"u": self.username, "p": self.password})
+            if self._legacyAuth:
+                parts[4].update({"u": self.username, "p": 'enc:%s' % self._hexEnc(self._rawPass)})
             parts[4] = urllib.urlencode(parts[4])
 
             return urlparse.urlunparse(parts)

--- a/lib/libsonic_extra/__init__.py
+++ b/lib/libsonic_extra/__init__.py
@@ -60,10 +60,11 @@ class SubsonicClient(libsonic.Connection):
         # Pick a default port
         host = "%s://%s" % (scheme, parts.hostname)
         port = parts.port or {"http": 80, "https": 443}[scheme]
+        path = parts.path.rstrip('/') + '/rest'
 
         # Invoke original constructor
         super(SubsonicClient, self).__init__(
-            host, username, password, port=port, appName='Kodi', apiVersion=apiversion, insecure=insecure, legacyAuth=legacyauth)
+            host, username, password, port=port, serverPath=path, appName='Kodi', apiVersion=apiversion, insecure=insecure, legacyAuth=legacyauth)
 
     def getIndexes(self, *args, **kwargs):
         """

--- a/main.py
+++ b/main.py
@@ -51,8 +51,8 @@ def get_connection():
         try:
             connection = libsonic_extra.SubsonicClient(
                 Addon().get_setting('subsonic_url'),
-                Addon().get_setting('username'),
-                Addon().get_setting('password'),
+                Addon().get_setting('username', convert=False),
+                Addon().get_setting('password', convert=False),
                 Addon().get_setting('apiversion'),
                 Addon().get_setting('insecure') == 'true',
                 Addon().get_setting('legacyauth') == 'true',


### PR DESCRIPTION
1) Fixes a security issue where the password is sent as plaintext in the URL query parameters when methods from libsonic_extas are used. Also adds Subsonic hex encoding when using legacy auth.

2) Adds support for URL paths like https://hostname.com/subsonic as requested in #17 and also encountered in some of the reports in #14 and #5 

3) Fixes an error when the password only contains digits, which simpleplugin converts to a Long, which later fails when libsonic tries to salt the password expecting a string.