### PR TITLE
Enable estimateContentLength to fix gapless playback issues.

### DIFF
--- a/main.py
+++ b/main.py
@@ -657,8 +657,9 @@ def play_track(params):
 
     url = connection.streamUrl(sid=id,
         maxBitRate=Addon().get_setting('bitrate_streaming'),
-        tformat=Addon().get_setting('transcode_format_streaming')
-    )
+        tformat=Addon().get_setting('transcode_format_streaming'),
+        estimateContentLength=True
+   )
 
     #return url
     _set_resolved_url(resolve_url(url))


### PR DESCRIPTION
Enable estimateContentLength, without it set the readahead buffer is disabled which can cause playback issues + affect gapless playback.