### PR TITLE
fix: set browser User-Agent to bypass Cloudflare WAF 403

### DIFF
--- a/lib/libsonic/connection.py
+++ b/lib/libsonic/connection.py
@@ -57,8 +57,10 @@ class HTTPSHandlerChain(urllib.request.HTTPSHandler):
     def https_open(self, req):
         return self.do_open(HTTPSConnectionChain, req, context=self._context)
 
-# install opener
-urllib.request.install_opener(urllib.request.build_opener(HTTPSHandlerChain()))
+# install opener (commented out — the global installer has no insecure context,
+# which breaks TLS behind Cloudflare/WAF. Each connection builds its own
+# opener via _getOpener() with the correct context.)
+# urllib.request.install_opener(urllib.request.build_opener(HTTPSHandlerChain()))
 
 class PysHTTPRedirectHandler(urllib.request.HTTPRedirectHandler):
     """
@@ -2783,6 +2785,11 @@ class Connection(object):
             PysHTTPRedirectHandler,
             https_chain,
         )
+        # Set a browser-like User-Agent so Cloudflare and other WAFs
+        # don't block requests (Python-urllib/3.x is often blocked).
+        opener.addheaders = [
+            ("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0"),
+        ]
         return opener
 
     def _getQueryDict(self, d):


### PR DESCRIPTION
### Problem

The Kodi Subsonic addon fails with `Connection error` / `HTTP Error 403: Forbidden` when the server is behind Cloudflare or any WAF that blocks the default `Python-urllib/3.x` User-Agent. This makes the addon completely unusable with any server fronted by Cloudflare.

### Root cause

Two issues in `lib/libsonic/connection.py`:

1. **Module-level `install_opener()` without insecure context** (line 61): A global `urllib` opener is installed at import time using `HTTPSHandlerChain()` with no SSL context. When TLS verification fails (e.g. behind a reverse proxy with a non-standard cert chain), the connection silently fails.

2. **Missing browser-like User-Agent** (line 2782): The opener built by `_getOpener()` uses Python urllib's default User-Agent (`Python-urllib/3.x`), which Cloudflare WAF and similar services block with HTTP 403.

### Changes

- **Comment out the module-level `install_opener()` call** — each `Connection()` already builds its own opener via `_getOpener()` with the correct insecure context when needed. The global installer was redundant and harmful.

- **Add a browser-like User-Agent to the opener** — `Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0` is sent as the User-Agent header, which passes Cloudflare WAF without issues.

### Testing

Tested against Navidrome v0.62.0 behind Cloudflare on Kodi 21 Omega / LibreELEC 12. With the patch:
- `ping` endpoint returns HTTP 200 (was 403)
- Album listing, search, and playback all work
- No regressions on direct connections (tested without Cloudflare)